### PR TITLE
Circle CI workflow to build and push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   docker: circleci/docker@2.1.3
+  go: circleci/go@1.7.1
 
 parameters:
   kustomize-version:
@@ -11,9 +12,10 @@ parameters:
 jobs:
   build:
     docker:
-     - image: golang:1.18-bullseye
+     - image: cimg/base:2022.08
     steps:
-      - checkout
+      - go/install:
+          version: "1.17"
       - run:
           name: "Install kustomize"
           command: |
@@ -24,4 +26,5 @@ jobs:
             $SUDO chmod +x ./kustomize
             $SUDO mv ./kustomize /usr/local/bin
       - docker/install-docker
+      - checkout
       - run: ./domino-build.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,6 @@ version: 2.1
 jobs:
   build:
     docker:
-     - image: cimg/base:2022.05
+     - image: golang:1.18-bullseye
     steps:
         - run: echo "Sample CircleCI job."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 orbs:
-  docker: circleci/docker@2.1.3
   go: circleci/go@1.7.1
 
 parameters:
@@ -25,6 +24,7 @@ jobs:
             [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
             $SUDO chmod +x ./kustomize
             $SUDO mv ./kustomize /usr/local/bin
-      - docker/install-docker
+      - setup_remote_docker:
+          version: 20.10.14
       - checkout
       - run: ./domino-build.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
     default: v4.5.7
 
 jobs:
-  build:
+  build-and-push:
     docker:
      - image: cimg/base:2022.08
     resource_class: medium
@@ -32,14 +32,14 @@ jobs:
           name: "Docker login"
           command: docker login ${DOCKER_REGISTRY} -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
       - run:
-          name: "Seldon-core Domino Build Script"
+          name: "Seldon-core Domino Build & Push Script"
           command: ./domino-build.sh
 
 workflows:
   version: 2
   main:
     jobs:
-      - build:
+      - build-and-push:
           context:
             - org-global
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,3 +34,20 @@ jobs:
       - run:
           name: "Seldon-core Domino Build Script"
           command: ./domino-build.sh
+
+workflows:
+  version: 2
+  main:
+    jobs:
+      - build:
+          context:
+            - org-global
+          filters:
+            tags:
+              only: /v\d+(\.\d+)*(-.*)*/
+#      - test:
+#          requires:
+#            - build
+#          filters:
+#            tags:
+#              only: /v\d+(\.\d+)*(-.*)*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     docker:
      - image: cimg/base:2022.08
+    resource_class: medium
     steps:
       - go/install:
           version: "1.17"
@@ -27,4 +28,9 @@ jobs:
       - setup_remote_docker:
           version: 20.10.14
       - checkout
-      - run: ./domino-build.sh
+      - run:
+          name: "Docker login"
+          command: docker login ${DOCKER_REGISTRY} -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+      - run:
+          name: "Seldon-core Domino Build Script"
+          command: ./domino-build.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  docker: circleci/docker@2.1.3
+
 parameters:
   kustomize-version:
     type: string
@@ -20,4 +23,5 @@ jobs:
             [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
             $SUDO chmod +x ./kustomize
             $SUDO mv ./kustomize /usr/local/bin
+      - docker/install-docker
       - run: ./domino-build.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,23 @@
 version: 2.1
 
+parameters:
+  kustomize-version:
+    type: string
+    default: v4.5.7
+
 jobs:
   build:
     docker:
      - image: golang:1.18-bullseye
     steps:
       - checkout
+      - run:
+          name: "Install kustomize"
+          command: |
+            URL=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/<< pipeline.parameters.kustomize-version >>/kustomize_<< pipeline.parameters.kustomize-version >>_linux_amd64.tar.gz
+            curl -L $URL | tar zx
+
+            [ -w /usr/local/bin ] && SUDO="" || SUDO=sudo
+            $SUDO chmod +x ./kustomize
+            $SUDO mv ./kustomize /usr/local/bin
       - run: ./domino-build.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,5 @@ jobs:
     docker:
      - image: golang:1.18-bullseye
     steps:
-        - run: echo "Sample CircleCI job."
+      - checkout
+      - run: ./domino-build.sh

--- a/domino-build.sh
+++ b/domino-build.sh
@@ -39,7 +39,7 @@ docker tag "seldonio/seldon-core-executor:${SOURCE_IMAGE_TAG}" "quay.io/domino/s
 
 if [ "${nopush_flag}" == "" ]; then
 
-  if [ "$(cat ~/.docker/config.json | jq '.auths | has("quay.io")')" == "true" ]; then
+  if [ -f ~/.docker/config.json ] && [ "$(cat ~/.docker/config.json | jq '.auths | has("quay.io")')" == "true" ]; then
     echo -e "[Docker is already logged into quay.io, using existing credentials.]"
   elif [ "${QUAY_USER:-missing}" != "missing" ] && [ "${QUAY_PASSWORD:-missing}" != "missing" ]; then
     echo "$QUAY_PASSWORD" | docker login -u "$QUAY_USER" --password-stdin quay.io


### PR DESCRIPTION
Adds a simple job to setup the required packages and run the `domino-build.sh` script to build the seldon-core operator and executor and push them to quay.io.