### PR TITLE
exit the seldon executor process if the RMQ connection dies

### DIFF
--- a/executor/api/rabbitmq/consumer.go
+++ b/executor/api/rabbitmq/consumer.go
@@ -65,8 +65,6 @@ func (c *consumer) Consume(
 		return fmt.Errorf("error '%w' consuming from rabbitmq queue", err)
 	}
 
-	// TODO does this need more error handling?  What about if the connection or channel fail while
-	// the handler is running?
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
@@ -102,6 +100,12 @@ func (c *consumer) Consume(
 		}
 	}
 	close(sigChan)
+
+	select {
+	case err = <-c.err:
+		return fmt.Errorf("error '%w' with rabbitmq connection", err)
+	default:
+	}
 
 	return nil
 }

--- a/executor/api/rabbitmq/rabbitmq_test.go
+++ b/executor/api/rabbitmq/rabbitmq_test.go
@@ -84,6 +84,10 @@ func (m *mockChannel) Qos(prefetchCount int, prefetchSize int, global bool) erro
 	return args.Error(0)
 }
 
+func (m *mockChannel) NotifyClose(receiver chan *amqp.Error) chan *amqp.Error {
+	return receiver
+}
+
 type TestPayload struct {
 	Msg string
 }

--- a/executor/api/rabbitmq/server.go
+++ b/executor/api/rabbitmq/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/seldonio/seldon-core/executor/api/grpc/seldon/proto"
+	"log"
 	"net/url"
 	"os"
 	"time"
@@ -34,7 +35,7 @@ const (
 	ENV_RABBITMQ_INPUT_QUEUE  = "RABBITMQ_INPUT_QUEUE"
 	ENV_RABBITMQ_OUTPUT_QUEUE = "RABBITMQ_OUTPUT_QUEUE"
 	ENV_RABBITMQ_FULL_GRAPH   = "RABBITMQ_FULL_GRAPH"
-	UNHANDLED_ERROR          = "Unhandled error from predictor process"
+	UNHANDLED_ERROR           = "Unhandled error from predictor process"
 )
 
 type SeldonRabbitMQServer struct {
@@ -121,6 +122,11 @@ func (rs *SeldonRabbitMQServer) Serve() error {
 		rs.Log.Error(err, "error connecting to rabbitmq")
 		return fmt.Errorf("error '%w' connecting to rabbitmq", err)
 	}
+
+	go func() {
+		err := <-conn.err
+		log.Fatal("RabbitMQ connection died", err) // causes app to exit with error
+	}()
 
 	return rs.serve(conn)
 }

--- a/executor/api/rabbitmq/types.go
+++ b/executor/api/rabbitmq/types.go
@@ -56,6 +56,7 @@ type Channel interface {
 	Nack(tag uint64, multiple bool, requeue bool) error
 	Reject(tag uint64, requeue bool) error
 	Qos(prefetchCount int, prefetchSize int, global bool) error
+	NotifyClose(receiver chan *amqp.Error) chan *amqp.Error
 }
 
 type SeldonPayloadWithHeaders struct {


### PR DESCRIPTION
Since the RMQ connection class does not reconnect if the connection fails, exit the executor entirely for now.
Later we will update to a better golang RMQ client to handle autoreconnect.