### PR TITLE
DOM-43199: Default max message size to 10KB if failed to read from annotations 

### DIFF
--- a/executor/api/rabbitmq/server.go
+++ b/executor/api/rabbitmq/server.go
@@ -213,7 +213,7 @@ func (rs *SeldonRabbitMQServer) predictAndPublishResponse(
 	msgLimit := annotations[k8s.ANNOTATION_RABBITMQ_MAX_MESSAGE_SIZE]
 	intMsgLimit, e := strconv.Atoi(msgLimit)
 	if intMsgLimit == 0 || e != nil {
-		rs.Log.Info("Failed to read maximum allowed message size defaulting to 10240 Bytes", "msg-size-found", intMsgLimit)
+		rs.Log.Info("Failed to read maximum allowed message size defaulting to 10240 bytes", "msg-size-found", intMsgLimit)
 		intMsgLimit = DEFAULT_MAX_MSG_SIZE_BYTES
 	}
 	rs.Log.Info("Maximum allowed message size for rabbitmq", "rabbitmq-max-message-size-in-bytes", intMsgLimit)

--- a/executor/api/rabbitmq/server.go
+++ b/executor/api/rabbitmq/server.go
@@ -213,6 +213,7 @@ func (rs *SeldonRabbitMQServer) predictAndPublishResponse(
 	msgLimit := annotations[k8s.ANNOTATION_RABBITMQ_MAX_MESSAGE_SIZE]
 	intMsgLimit, e := strconv.Atoi(msgLimit)
 	if intMsgLimit == 0 || e != nil {
+		rs.Log.Info("Failed to read maximum allowed message size defaulting to 10240 Bytes", "msg-size-found", intMsgLimit)
 		intMsgLimit = DEFAULT_MAX_MSG_SIZE_BYTES
 	}
 	rs.Log.Info("Maximum allowed message size for rabbitmq", "rabbitmq-max-message-size-in-bytes", intMsgLimit)

--- a/executor/api/rabbitmq/server.go
+++ b/executor/api/rabbitmq/server.go
@@ -34,11 +34,12 @@ import (
  */
 
 const (
-	ENV_RABBITMQ_BROKER_URL   = "RABBITMQ_BROKER_URL"
-	ENV_RABBITMQ_INPUT_QUEUE  = "RABBITMQ_INPUT_QUEUE"
-	ENV_RABBITMQ_OUTPUT_QUEUE = "RABBITMQ_OUTPUT_QUEUE"
-	ENV_RABBITMQ_FULL_GRAPH   = "RABBITMQ_FULL_GRAPH"
-	UNHANDLED_ERROR           = "Unhandled error from predictor process"
+	ENV_RABBITMQ_BROKER_URL    = "RABBITMQ_BROKER_URL"
+	ENV_RABBITMQ_INPUT_QUEUE   = "RABBITMQ_INPUT_QUEUE"
+	ENV_RABBITMQ_OUTPUT_QUEUE  = "RABBITMQ_OUTPUT_QUEUE"
+	ENV_RABBITMQ_FULL_GRAPH    = "RABBITMQ_FULL_GRAPH"
+	UNHANDLED_ERROR            = "Unhandled error from predictor process"
+	DEFAULT_MAX_MSG_SIZE_BYTES = 10240
 )
 
 type SeldonRabbitMQServer struct {
@@ -210,7 +211,10 @@ func (rs *SeldonRabbitMQServer) predictAndPublishResponse(
 	}
 	annotations, _ := k8s.GetAnnotations()
 	msgLimit := annotations[k8s.ANNOTATION_RABBITMQ_MAX_MESSAGE_SIZE]
-	intMsgLimit, _ := strconv.Atoi(msgLimit)
+	intMsgLimit, e := strconv.Atoi(msgLimit)
+	if intMsgLimit == 0 || e != nil {
+		intMsgLimit = DEFAULT_MAX_MSG_SIZE_BYTES
+	}
 	rs.Log.Info("Maximum allowed message size for rabbitmq", "rabbitmq-max-message-size-in-bytes", intMsgLimit)
 	if len(arrBytes) > intMsgLimit {
 		message := &proto.SeldonMessage{


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
We Observed during e2e testing on vCluster that it applies labels which Seldon core executor does not like and after failing to read annotations it sets the max message value to 0 which causes all prediction payload size checks to fail.

With this PR:
If ever intMsgLimit is set to 0, due to failure to read annotation or accidentally set, we will reset the value to 10240 Bytes. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes DOM-43199

**Special notes for your reviewer**:
This issue is due to this label applied by vCluster:
"vcluster.loft.sh/labels": Some value
