### PR TITLE
use golang:1.20-bookworm as it tracks the latest go 1.20 release

### DIFF
--- a/executor/Dockerfile.executor
+++ b/executor/Dockerfile.executor
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20.10-bookworm as builder
+FROM golang:1.20-bookworm as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/executor/Dockerfile.executor
+++ b/executor/Dockerfile.executor
@@ -1,4 +1,5 @@
 # Build the manager binary
+# 1.20-bookworm image points to the latest go 1.20.x
 FROM golang:1.20-bookworm as builder
 
 WORKDIR /workspace

--- a/executor/Dockerfile.executor.redhat
+++ b/executor/Dockerfile.executor.redhat
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20.10-bookworm as builder
+FROM golang:1.17.13-buster as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20.10-bookworm as builder
+FROM golang:1.20-bookworm as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,4 +1,5 @@
 # Build the manager binary
+# 1.20-bookworm image points to the latest go 1.20.x
 FROM golang:1.20-bookworm as builder
 
 WORKDIR /workspace


### PR DESCRIPTION
note: we don't use `executor/Dockerfile.executor.redhat` so reverting this back to the version from upstream seldon-core