### PR TITLE
VUL-3644 VUL-3645 Upgrade seldon-core operator & executor go to 1.23

### DIFF
--- a/executor/Dockerfile.executor
+++ b/executor/Dockerfile.executor
@@ -1,6 +1,6 @@
 # Build the manager binary
-# 1.22-bookworm image points to the latest go 1.22.x
-FROM golang:1.22-bookworm as builder
+# 1.23-bookworm image points to the latest go 1.23.x
+FROM golang:1.23-bookworm as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/executor/go.mod
+++ b/executor/go.mod
@@ -1,6 +1,6 @@
 module github.com/seldonio/seldon-core/executor
 
-go 1.22
+go 1.23
 
 require (
 	github.com/cloudevents/sdk-go v1.2.0

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
-# 1.22-bookworm image points to the latest go 1.22.x
-FROM golang:1.22-bookworm as builder
+# 1.23-bookworm image points to the latest go 1.23.x
+FROM golang:1.23-bookworm as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/seldonio/seldon-core/operator
 
-go 1.22
+go 1.23
 
 require (
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

https://dominodatalab.atlassian.net/browse/VUL-3644
https://dominodatalab.atlassian.net/browse/VUL-3645

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Upgrade seldon-core operator & executor go to 1.23 to fix CVE-2025-22871

Scan results confirmed that the CVE is fixed:
```
/scan quay.io/domino/seldon-core-operator:1.16.0-domino-dev-po.VUL-3645.upgrade-go.latest
```
https://dominodatalab.slack.com/archives/C02KU0JNTSN/p1748060495937779

**Special notes for your reviewer**:
