### PR TITLE
DOM-70343 Change QoS global setting to false

### DIFF
--- a/executor/api/rabbitmq/connection.go
+++ b/executor/api/rabbitmq/connection.go
@@ -123,7 +123,7 @@ func (c *connection) connect() error {
 		err = c.channel.Qos(
 			1,
 			0,
-			true,
+			false,
 		)
 		if err != nil {
 			c.log.Error(err, "error setting rabbitmq Qos")

--- a/executor/api/rabbitmq/connection_test.go
+++ b/executor/api/rabbitmq/connection_test.go
@@ -58,7 +58,7 @@ func TestNewConnection(t *testing.T) {
 
 	t.Run("connect", func(t *testing.T) {
 		f, reset := setupConnect(func(adapter *mockDialerAdapter, conn *mockConnection, channel *mockChannel) {
-			channel.On("Qos", 1, 0, true).Return(nil)
+			channel.On("Qos", 1, 0, false).Return(nil)
 			conn.On("Channel").Return(channel, nil)
 			adapter.On("Dial", uri).Return(conn, nil)
 		})
@@ -77,7 +77,7 @@ func TestNewConnection(t *testing.T) {
 
 	t.Run("reconnect", func(t *testing.T) {
 		f, reset := setupConnect(func(adapter *mockDialerAdapter, conn *mockConnection, channel *mockChannel) {
-			channel.On("Qos", 1, 0, true).Return(nil)
+			channel.On("Qos", 1, 0, false).Return(nil)
 			conn.On("Channel").Return(channel, nil)
 			adapter.On("Dial", uri).Return(nil, errors.New("test dial error")).Once()
 			adapter.On("Dial", uri).Return(conn, nil).Once()

--- a/executor/api/rabbitmq/publisher_test.go
+++ b/executor/api/rabbitmq/publisher_test.go
@@ -68,7 +68,7 @@ func TestPublisher(t *testing.T) {
 
 	t.Run("connection_closed", func(t *testing.T) {
 		f, reset := setupConnect(func(adapter *mockDialerAdapter, conn *mockConnection, channel *mockChannel) {
-			channel.On("Qos", 1, 0, true).Return(nil)
+			channel.On("Qos", 1, 0, false).Return(nil)
 			channel.On("Publish", "", queueName, true, false, amqp.Publishing{
 				Headers:      make(map[string]interface{}),
 				ContentType:  "application/json",
@@ -101,7 +101,7 @@ func TestPublisher(t *testing.T) {
 
 	t.Run("connection_closed_retry", func(t *testing.T) {
 		f, reset := setupConnect(func(adapter *mockDialerAdapter, conn *mockConnection, channel *mockChannel) {
-			channel.On("Qos", 1, 0, true).Return(nil)
+			channel.On("Qos", 1, 0, false).Return(nil)
 			channel.On("Publish", "", queueName, true, false, amqp.Publishing{
 				Headers:      make(map[string]interface{}),
 				ContentType:  "application/json",

--- a/executor/api/rest/client_test.go
+++ b/executor/api/rest/client_test.go
@@ -338,7 +338,11 @@ func TestTimeout(t *testing.T) {
 	err = jsonpb.UnmarshalString(string(data), &smRes)
 	g.Expect(err).Should(BeNil())
 	g.Expect(smRes.GetStatus().GetCode()).Should(BeEquivalentTo(int32(500)))
-	g.Expect(smRes.GetStatus().GetInfo()).Should(ContainSubstring("Client.Timeout exceeded while awaiting headers"))
+	info := smRes.GetStatus().GetInfo()
+	g.Expect(info).Should(Or(
+		ContainSubstring("context deadline exceeded"),
+		ContainSubstring("Client.Timeout exceeded while awaiting headers"),
+	))
 }
 
 func TestMarshall(t *testing.T) {


### PR DESCRIPTION
https://dominodatalab.atlassian.net/browse/DOM-70343

<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:

Fixes RabbitMQ connectivity issue in seldon-core executor by changing the QoS global setting from true to false. This was necessary because the recent RabbitMQ upgrade to 4.1.3 no longer supports global QoS on quorum queues, causing the executor to fail with "NOT_IMPLEMENTED" errors when trying to connect.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
- Resolves the error: Exception (540) Reason: "NOT_IMPLEMENTED - queue does not support global qos"
- Fixes the timeout test

**Special notes for your reviewer**:

The change from `global=true` to `global=false` is safe because:
- Each seldon-core executor uses a single consumer per channel
- The global setting wasn't providing any additional benefit
- The core behavior (prefetch=1) remains unchanged

This is a low-risk change that addresses the compatibility issue without affecting functionality.
