### PR TITLE
VUL-8616: Bump go 1.24.11 -> 1.24.12

### DIFF
--- a/.github/workflows/executor_lint.yml
+++ b/.github/workflows/executor_lint.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v3      
+    - uses: actions/setup-go@v3
       with:
-        go-version: '1.24.11'
+        go-version: '1.24.12'
     - name: test-executor
       env:
-        GOTOOLCHAIN: go1.24.11
+        GOTOOLCHAIN: go1.24.12
       run: |
         make -C executor lint

--- a/.github/workflows/executor_tests.yml
+++ b/.github/workflows/executor_tests.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v3      
+    - uses: actions/setup-go@v3
       with:
-        go-version: '1.24.11'
+        go-version: '1.24.12'
     - name: test-executor
       env:
-        GOTOOLCHAIN: go1.24.11
+        GOTOOLCHAIN: go1.24.12
       run: |
         make -C executor test

--- a/.github/workflows/operator_lint.yml
+++ b/.github/workflows/operator_lint.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v3      
+    - uses: actions/setup-go@v3
       with:
-        go-version: '1.24.11'
+        go-version: '1.24.12'
     - name: test-executor
       env:
-        GOTOOLCHAIN: go1.24.11
+        GOTOOLCHAIN: go1.24.12
       run: |
         make -C operator lint

--- a/.github/workflows/operator_tests.yml
+++ b/.github/workflows/operator_tests.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v3      
+    - uses: actions/setup-go@v3
       with:
-        go-version: '1.24.11'
+        go-version: '1.24.12'
     - name: test-operator
       env:
-        GOTOOLCHAIN: go1.24.11
+        GOTOOLCHAIN: go1.24.12
       run: |
         make -C operator test

--- a/executor/Dockerfile.executor
+++ b/executor/Dockerfile.executor
@@ -1,6 +1,6 @@
 # Build the manager binary
-# 1.24.11-bookworm image points to go 1.24.11
-FROM golang:1.24.11-bookworm as builder
+# 1.24.12-bookworm image points to go 1.24.12
+FROM golang:1.24.12-bookworm as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/executor/go.mod
+++ b/executor/go.mod
@@ -1,6 +1,6 @@
 module github.com/seldonio/seldon-core/executor
 
-go 1.24.11
+go 1.24.12
 
 require (
 	github.com/cloudevents/sdk-go v1.2.0

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
-# 1.24.11-bookworm image points to go 1.24.11
-FROM golang:1.24.11-bookworm as builder
+# 1.24.12-bookworm image points to go 1.24.12
+FROM golang:1.24.12-bookworm as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/seldonio/seldon-core/operator
 
-go 1.24.11
+go 1.24.12
 
 require (
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0


### PR DESCRIPTION
This is Bumping go from 1.24.11 to 1.24.12 to fix some vulns

https://dominodatalab.atlassian.net/browse/VUL-8616