### PR TITLE
Changing codeowners to eng-pham

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dominodatalab/seldon-core-maintainers
+* @dominodatalab/eng-pham


### PR DESCRIPTION
This PR Updates the codeowners to point to eng-pham instead of seldon-core-maintainers which is empty right now