### PR TITLE
Bump setup-envtest to 0.19

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -212,7 +212,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 ENVTEST = $(shell pwd)/bin/setup-envtest
 .PHONY: envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.18)
+	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19)
 
 
 # go-get-tool will 'go get' any package $2 and install it to $1.

--- a/test/seldon/model/test-models
+++ b/test/seldon/model/test-models
@@ -17,7 +17,7 @@ IRIS_RESULT_PAYLOAD=$(with_backoff kubectl -n $COMPUTE_NAMESPACE exec deployment
     curl -X POST http://localhost:8000/api/v1.0/predictions \
     -H 'Content-Type: application/json' -d '{"data": {"ndarray": [[1,2,3,4]] }}')
 if [ "${EXPECTED_IRIS_RESULT_PAYLOAD}" != "${IRIS_RESULT_PAYLOAD}" ]; then
-  echo "UNEXPECTED IRIS MODEL RESULT: ${IRIS_RESULT_PAYLOAD}"
+  echo "UNEXPECTED IRIS MODEL RESULT: '${IRIS_RESULT_PAYLOAD}'"
   exit 1
 fi
 

--- a/test/seldon/model/test-models
+++ b/test/seldon/model/test-models
@@ -9,7 +9,7 @@ source "${COMMON_DIR}/with_backoff.sh"
 
 COMPUTE_NAMESPACE=seldon-regression-test
 
-EXPECTED_IRIS_RESULT_PAYLOAD='{"data":{"names":["t:0","t:1","t:2"],"ndarray":[[0.0006985194531162835,0.00366803903943666,0.995633441507447]]},"meta":{"requestPath":{"classifier":"seldonio/sklearnserver:1.17.1"}}}'
+EXPECTED_IRIS_RESULT_PAYLOAD='{"data":{"names":["t:0","t:1","t:2"],"ndarray":[[0.0006985194531162835,0.00366803903943666,0.995633441507447]]},"meta":{"requestPath":{"classifier":"seldonio/sklearnserver:1.19.0"}}}'
 EXPECTED_MOCK_RESULT_PAYLOAD='{"data":{"names":["proba"],"ndarray":[[0.43782349911420193]]},"meta":{"requestPath":{"classifier":"seldonio/mock_classifier:1.7.0-dev"}}}'
 
 echo ">>> Testing iris model..."

--- a/test/seldon/model/test-rabbit-models
+++ b/test/seldon/model/test-rabbit-models
@@ -12,7 +12,7 @@ COMPUTE_NAMESPACE=seldon-regression-test
 
 RABBITMQ_USER=$(kubectl -n rabbitmq get secret rabbitmq-cluster-default-user -o jsonpath="{.data.username}" | base64 --decode)
 RABBITMQ_PASSWORD=$(kubectl -n rabbitmq get secret rabbitmq-cluster-default-user -o jsonpath="{.data.password}" | base64 --decode)
-EXPECTED_IRIS_RESULT_PAYLOAD='{"data":{"names":["t:0","t:1","t:2"],"ndarray":[[0.0006985194531162835,0.00366803903943666,0.995633441507447]]},"meta":{"requestPath":{"classifier":"seldonio/sklearnserver:1.17.1"}}}'
+EXPECTED_IRIS_RESULT_PAYLOAD='{"data":{"names":["t:0","t:1","t:2"],"ndarray":[[0.0006985194531162835,0.00366803903943666,0.995633441507447]]},"meta":{"requestPath":{"classifier":"seldonio/sklearnserver:1.19.0"}}}'
 
 # Port-forward RabbitMQ management API to avoid needing curl in the container
 # Port-forward to the pod directly since the management API might not be exposed on the service
@@ -36,22 +36,22 @@ done
 
 echo ">>> Sending predict message to iris rabbitmq model input queue..."
 curl -X POST "http://localhost:15672/api/exchanges/%2F/amq.default/publish" \
-    --user "${RABBITMQ_USER}:${RABBITMQ_PASSWORD}" \
-    -H "Content-type: application/json" \
-    -H "Accept: application/json" \
-    -d '{"properties":{"content_type":"application/json"},"routing_key":"iris-model-rabbitmq-input","payload":"{\"data\": {\"ndarray\": [[1,2,3,4]] }}","payload_encoding":"string"}'
+  --user "${RABBITMQ_USER}:${RABBITMQ_PASSWORD}" \
+  -H "Content-type: application/json" \
+  -H "Accept: application/json" \
+  -d '{"properties":{"content_type":"application/json"},"routing_key":"iris-model-rabbitmq-input","payload":"{\"data\": {\"ndarray\": [[1,2,3,4]] }}","payload_encoding":"string"}'
 
 function retrieveIrisResult {
   IRIS_RESULT_PAYLOAD=$(curl -X POST "http://localhost:15672/api/queues/%2F/iris-model-rabbitmq-output/get" \
-      --user "${RABBITMQ_USER}:${RABBITMQ_PASSWORD}" \
-      -H "Content-type: application/json" \
-      -H "Accept: application/json" \
-      -d '{"count":1,"ackmode":"ack_requeue_false","encoding":"auto"}' | jq -e -r '.[0].payload')
+    --user "${RABBITMQ_USER}:${RABBITMQ_PASSWORD}" \
+    -H "Content-type: application/json" \
+    -H "Accept: application/json" \
+    -d '{"count":1,"ackmode":"ack_requeue_false","encoding":"auto"}' | jq -e -r '.[0].payload')
 }
 with_backoff retrieveIrisResult
 
 if [ "${EXPECTED_IRIS_RESULT_PAYLOAD}" != "${IRIS_RESULT_PAYLOAD}" ]; then
-  echo "UNEXPECTED IRIS MODEL RESULT: ${IRIS_RESULT_PAYLOAD}"
+  echo "UNEXPECTED IRIS MODEL RESULT: '${IRIS_RESULT_PAYLOAD}'"
   exit 1
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the pipeline. `setup-envtest` downloads the k8s binaries for the tests, and the version 0.18 used a deprecated source for the binaries. Bumping to 0.19 fixed that issue

In the iris tests the classifier changed to `"seldonio/sklearnserver:1.19.0"`, but the rest of the output remains the same

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
