### PR TITLE
VUL-21520: Bump Go to 1.25.12

### DIFF
--- a/.github/workflows/executor_lint.yml
+++ b/.github/workflows/executor_lint.yml
@@ -15,9 +15,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.25.11'
+        go-version: '1.25.12'
     - name: test-executor
       env:
-        GOTOOLCHAIN: go1.25.11
+        GOTOOLCHAIN: go1.25.12
       run: |
         make -C executor lint

--- a/.github/workflows/executor_tests.yml
+++ b/.github/workflows/executor_tests.yml
@@ -15,9 +15,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.25.11'
+        go-version: '1.25.12'
     - name: test-executor
       env:
-        GOTOOLCHAIN: go1.25.11
+        GOTOOLCHAIN: go1.25.12
       run: |
         make -C executor test

--- a/.github/workflows/operator_lint.yml
+++ b/.github/workflows/operator_lint.yml
@@ -15,9 +15,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.25.11'
+        go-version: '1.25.12'
     - name: test-executor
       env:
-        GOTOOLCHAIN: go1.25.11
+        GOTOOLCHAIN: go1.25.12
       run: |
         make -C operator lint

--- a/.github/workflows/operator_tests.yml
+++ b/.github/workflows/operator_tests.yml
@@ -15,9 +15,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.25.11'
+        go-version: '1.25.12'
     - name: test-operator
       env:
-        GOTOOLCHAIN: go1.25.11
+        GOTOOLCHAIN: go1.25.12
       run: |
         make -C operator test

--- a/executor/Dockerfile.executor
+++ b/executor/Dockerfile.executor
@@ -1,6 +1,6 @@
 # Build the manager binary
-# 1.25.11-bookworm image points to go 1.25.11
-FROM golang:1.25.11-bookworm as builder
+# 1.25.12-bookworm image points to go 1.25.12
+FROM golang:1.25.12-bookworm as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/executor/go.mod
+++ b/executor/go.mod
@@ -1,6 +1,6 @@
 module github.com/seldonio/seldon-core/executor
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/cloudevents/sdk-go v1.2.0

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,6 +1,6 @@
 # Build the manager binary
-# 1.25.11-bookworm image points to go 1.25.11
-FROM golang:1.25.11-bookworm as builder
+# 1.25.12-bookworm image points to go 1.25.12
+FROM golang:1.25.12-bookworm as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/seldonio/seldon-core/operator
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0


### PR DESCRIPTION
## Summary
- Bump Go from 1.25.11 to 1.25.12 across executor and operator (go.mod, Dockerfiles, and CI workflows)
- No dependency updates required (`go mod tidy` produced no go.sum changes for this patch bump)

## Test plan
- [x] `go build ./...` passes for operator
- [x] `go build ./...` for executor confirmed unaffected by this change (pre-existing local librdkafka linking issue, unrelated to Go version, reproduced identically on the base commit)
- [ ] CI lint/test workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)