### PR TITLE
[skip ci] Switch to using seldon-core-quay context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,13 +91,13 @@ workflows:
     jobs:
       - build-and-push:
           context:
-            - org-global
+            - seldon-core-quay
           filters:
             tags:
               only: /\d+(\.\d+)*(-.*)*-rabbitmq(-.*)*/
       - test:
           context:
-            - org-global
+            - seldon-core-quay
           requires:
             - build-and-push
           filters:

--- a/executor/Makefile
+++ b/executor/Makefile
@@ -20,6 +20,7 @@ IMAGE_BASE_DOCKERFILE := "https://github.com/dominodatalab/seldon-core/blob/rabb
 # These should be set in CI, but in case we are running locally, let's set some default values
 CIRCLE_SHA1 ?= $(shell git rev-parse HEAD)
 CIRCLE_BUILD_URL ?= "local"
+CIRCLE_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -111,7 +112,8 @@ docker-build: test copy_openapi_resources
 		--label "org.opencontainers.image.revision=${CIRCLE_SHA1}" \
 		--label "com.dominodatalab.image.osrp.datetime=${BUILD_DATE}" \
 		--label "com.dominodatalab.image.dockerfile=${IMAGE_BASE_DOCKERFILE}" \
-		--label "com.dominodatalab.ci.build-url=${CIRCLE_BUILD_URL}"
+		--label "com.dominodatalab.ci.build-url=${CIRCLE_BUILD_URL}" \
+		--label "com.dominodatalab.image.git-branch=${CIRCLE_BRANCH}"
 
 # Build the docker image for Redhat
 docker-build-redhat: test copy_openapi_resources

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -18,6 +18,7 @@ IMAGE_BASE_DOCKERFILE := "https://github.com/dominodatalab/seldon-core/blob/rabb
 # These should be set in CI, but in case we are running locally, let's set some default values
 CIRCLE_SHA1 ?= $(shell git rev-parse HEAD)
 CIRCLE_BUILD_URL ?= "local"
+CIRCLE_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -166,7 +167,8 @@ docker-build: test generate-resources
 		--label "org.opencontainers.image.revision=${CIRCLE_SHA1}" \
 		--label "com.dominodatalab.image.osrp.datetime=${BUILD_DATE}" \
 		--label "com.dominodatalab.image.dockerfile=${IMAGE_BASE_DOCKERFILE}" \
-		--label "com.dominodatalab.ci.build-url=${CIRCLE_BUILD_URL}"
+		--label "com.dominodatalab.ci.build-url=${CIRCLE_BUILD_URL}" \
+		--label "com.dominodatalab.image.git-branch=${CIRCLE_BRANCH}"
 
 # Build the docker image without testing
 docker-build-no-test: generate-resources
@@ -176,7 +178,8 @@ docker-build-no-test: generate-resources
 		--label "org.opencontainers.image.revision=${CIRCLE_SHA1}" \
 		--label "com.dominodatalab.image.osrp.datetime=${BUILD_DATE}" \
 		--label "com.dominodatalab.image.dockerfile=${IMAGE_BASE_DOCKERFILE}" \
-		--label "com.dominodatalab.ci.build-url=${CIRCLE_BUILD_URL}"
+		--label "com.dominodatalab.ci.build-url=${CIRCLE_BUILD_URL}" \
+		--label "com.dominodatalab.image.git-branch=${CIRCLE_BRANCH}"
 
 # Build the docker image for Redhat
 docker-build-redhat: test generate-resources


### PR DESCRIPTION
<!--
Thanks for sending a pull request! 
If this is your first time, please read our contributor guidelines:
https://docs.seldon.io/projects/seldon-core/en/latest/developer/contributing.html
-->

**What this PR does / why we need it**:
The `org-global` CircleCI context is deprecated. Let's switch over to the `seldon-core-quay` context.

**Which issue(s) this PR fixes**:
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Special notes for your reviewer**:
Going to merge with the `[skip ci]` commit message, so we don't unnecessarily create a Docker image upon merge.